### PR TITLE
Revised Current Inquiries

### DIFF
--- a/Survey/Survey.xcodeproj/project.pbxproj
+++ b/Survey/Survey.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C9377D242CA24EBC00D51356 /* InquiryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9377D232CA24EBC00D51356 /* InquiryModel.swift */; };
+		C9377D262CA24EF900D51356 /* SurveyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9377D252CA24EF900D51356 /* SurveyModel.swift */; };
+		C9377D292CA24F2C00D51356 /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9377D282CA24F2C00D51356 /* MockServer.swift */; };
+		C9377D2C2CA24F6E00D51356 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9377D2B2CA24F6E00D51356 /* Logger.swift */; };
+		C9377D2E2CA24F9200D51356 /* db.json in Resources */ = {isa = PBXBuildFile; fileRef = C9377D2D2CA24F9200D51356 /* db.json */; };
 		C99701AD2C9A468F009A3039 /* SurveyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99701AC2C9A468F009A3039 /* SurveyApp.swift */; };
 		C99701AF2C9A468F009A3039 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99701AE2C9A468F009A3039 /* ContentView.swift */; };
 		C99701B12C9A468F009A3039 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99701B02C9A468F009A3039 /* Item.swift */; };
@@ -38,6 +43,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C9377D232CA24EBC00D51356 /* InquiryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryModel.swift; sourceTree = "<group>"; };
+		C9377D252CA24EF900D51356 /* SurveyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyModel.swift; sourceTree = "<group>"; };
+		C9377D282CA24F2C00D51356 /* MockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServer.swift; sourceTree = "<group>"; };
+		C9377D2B2CA24F6E00D51356 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		C9377D2D2CA24F9200D51356 /* db.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = db.json; sourceTree = "<group>"; };
 		C99701A92C9A468F009A3039 /* Survey.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Survey.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C99701AC2C9A468F009A3039 /* SurveyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyApp.swift; sourceTree = "<group>"; };
 		C99701AE2C9A468F009A3039 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -80,11 +90,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		C96DB3742C9D0CF900D7001D /* Preview Content */ = {
+		C9377D222CA24E9900D51356 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C9377D232CA24EBC00D51356 /* InquiryModel.swift */,
+				C9377D252CA24EF900D51356 /* SurveyModel.swift */,
 			);
-			path = "Preview Content";
+			path = Models;
+			sourceTree = "<group>";
+		};
+		C9377D272CA24F1C00D51356 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				C9377D282CA24F2C00D51356 /* MockServer.swift */,
+				C9377D2D2CA24F9200D51356 /* db.json */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		C9377D2A2CA24F4E00D51356 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				C9377D2B2CA24F6E00D51356 /* Logger.swift */,
+			);
+			name = Helpers;
 			sourceTree = "<group>";
 		};
 		C99701A02C9A468F009A3039 = {
@@ -111,7 +140,9 @@
 		C99701AB2C9A468F009A3039 /* Survey */ = {
 			isa = PBXGroup;
 			children = (
-				C96DB3742C9D0CF900D7001D /* Preview Content */,
+				C9377D2A2CA24F4E00D51356 /* Helpers */,
+				C9377D272CA24F1C00D51356 /* Network */,
+				C9377D222CA24E9900D51356 /* Models */,
 				C99701B72C9A4690009A3039 /* Survey.entitlements */,
 				C99701AE2C9A468F009A3039 /* ContentView.swift */,
 				C99701DF2C9A4F21009A3039 /* SurveyView.swift */,
@@ -268,6 +299,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9377D2E2CA24F9200D51356 /* db.json in Resources */,
 				C99701B62C9A4690009A3039 /* Preview Assets.xcassets in Resources */,
 				C99701B32C9A4690009A3039 /* Assets.xcassets in Resources */,
 			);
@@ -295,9 +327,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C99701E02C9A4F21009A3039 /* SurveyView.swift in Sources */,
+				C9377D262CA24EF900D51356 /* SurveyModel.swift in Sources */,
+				C9377D292CA24F2C00D51356 /* MockServer.swift in Sources */,
 				C99701AF2C9A468F009A3039 /* ContentView.swift in Sources */,
 				C99701B12C9A468F009A3039 /* Item.swift in Sources */,
 				C99701AD2C9A468F009A3039 /* SurveyApp.swift in Sources */,
+				C9377D242CA24EBC00D51356 /* InquiryModel.swift in Sources */,
+				C9377D2C2CA24F6E00D51356 /* Logger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -461,12 +497,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Survey/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"Survey\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -475,11 +511,11 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "Incredihire-LLC.Survey";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -492,12 +528,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Survey/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"Survey\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -506,11 +542,11 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "Incredihire-LLC.Survey";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Survey/Survey.xcodeproj/project.pbxproj
+++ b/Survey/Survey.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Survey/Survey.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -502,7 +503,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -511,11 +512,10 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "Incredihire-LLC.Survey";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -525,6 +525,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Survey/Survey.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -533,7 +534,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -542,11 +543,10 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "Incredihire-LLC.Survey";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Survey/Survey.xcodeproj/project.pbxproj
+++ b/Survey/Survey.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C99701DC2C9A4893009A3039 /* SwiftUIX in Frameworks */ = {isa = PBXBuildFile; productRef = C99701DB2C9A4893009A3039 /* SwiftUIX */; };
 		C99701E02C9A4F21009A3039 /* SurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99701DF2C9A4F21009A3039 /* SurveyView.swift */; };
 		C99701E22C9A63BE009A3039 /* SwiftUIX in Frameworks */ = {isa = PBXBuildFile; productRef = C99701E12C9A63BE009A3039 /* SwiftUIX */; };
+		C9E003602CA3A603009E6DD5 /* InquiryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E0035F2CA3A603009E6DD5 /* InquiryService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		C99701CA2C9A4690009A3039 /* SurveyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyUITests.swift; sourceTree = "<group>"; };
 		C99701CC2C9A4690009A3039 /* SurveyUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		C99701DF2C9A4F21009A3039 /* SurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyView.swift; sourceTree = "<group>"; };
+		C9E0035F2CA3A603009E6DD5 /* InquiryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InquiryService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +106,7 @@
 			children = (
 				C9377D282CA24F2C00D51356 /* MockServer.swift */,
 				C9377D2D2CA24F9200D51356 /* db.json */,
+				C9E0035F2CA3A603009E6DD5 /* InquiryService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 				C99701AF2C9A468F009A3039 /* ContentView.swift in Sources */,
 				C99701B12C9A468F009A3039 /* Item.swift in Sources */,
 				C99701AD2C9A468F009A3039 /* SurveyApp.swift in Sources */,
+				C9E003602CA3A603009E6DD5 /* InquiryService.swift in Sources */,
 				C9377D242CA24EBC00D51356 /* InquiryModel.swift in Sources */,
 				C9377D2C2CA24F6E00D51356 /* Logger.swift in Sources */,
 			);

--- a/Survey/Survey.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Survey/Survey.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Survey/Survey.xcodeproj/xcshareddata/xcschemes/Survey.xcscheme
+++ b/Survey/Survey.xcodeproj/xcshareddata/xcschemes/Survey.xcscheme
@@ -74,6 +74,13 @@
             ReferencedContainer = "container:Survey.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Survey/Survey/ContentView.swift
+++ b/Survey/Survey/ContentView.swift
@@ -1,16 +1,12 @@
 import SwiftUI
-
 struct ContentView: View {
     @StateObject private var viewModel = SurveyViewModel()
-
     var body: some View {
         VStack {
-            if viewModel.inquiries.isEmpty {
-                EmptyView()
+            if let inquiry = viewModel.inquiries.first {
+                SurveyView(question: inquiry.question)
             } else {
-                ForEach(viewModel.inquiries) { inquiry in
-                    SurveyView(question: inquiry.question)
-                }
+                EmptyView()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Survey/Survey/ContentView.swift
+++ b/Survey/Survey/ContentView.swift
@@ -1,13 +1,22 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        SurveyView()
-    }
-}
+    @StateObject private var viewModel = SurveyViewModel()
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+    var body: some View {
+        VStack {
+            if viewModel.inquiries.isEmpty {
+                EmptyView()
+            } else {
+                ForEach(viewModel.inquiries) { inquiry in
+                    SurveyView(question: inquiry.question)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.white)
+        .onAppear {
+            viewModel.loadInquiries()
+        }
     }
 }

--- a/Survey/Survey/Logger.swift
+++ b/Survey/Survey/Logger.swift
@@ -6,16 +6,18 @@ class Logger {
     private let log: OSLog
 
     private init() {
-        self.log = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "Incredihire-LLC.Survey", category: "MockServer")
+        self.log = OSLog(
+            subsystem: Bundle.main.bundleIdentifier ?? "Incredihire-LLC.Survey",
+            category: "MockServer"
+        )
     }
-
-    func log(error: Error, customMessage: String? = nil) {
-        let message = customMessage != nil ? "\(customMessage!): \(error.localizedDescription)" : error.localizedDescription
+ func log(error: Error, customMessage: String? = nil) {
+        let message = customMessage != nil
+            ? "\(customMessage!): \(error.localizedDescription)"
+            : error.localizedDescription
         os_log("Error logged: %@", log: log, type: .error, message)
     }
-
-    func log(message: String) {
+ func log(message: String) {
         os_log("%@", log: log, type: .info, message)
     }
 }
-

--- a/Survey/Survey/Logger.swift
+++ b/Survey/Survey/Logger.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class Logger {
+    static let shared = Logger()
+    private init() {}
+    func log(error: Error) {
+        print("Error logged: \(error.localizedDescription)")
+    }
+}

--- a/Survey/Survey/Logger.swift
+++ b/Survey/Survey/Logger.swift
@@ -6,12 +6,16 @@ class Logger {
     private let log: OSLog
 
     private init() {
-        self.log = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.yourapp.default", category: "General")
+        self.log = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "Incredihire-LLC.Survey", category: "MockServer")
     }
-    func log(error: Error) {
-        os_log("Error logged: %@", log: log, type: .error, error.localizedDescription)
+
+    func log(error: Error, customMessage: String? = nil) {
+        let message = customMessage != nil ? "\(customMessage!): \(error.localizedDescription)" : error.localizedDescription
+        os_log("Error logged: %@", log: log, type: .error, message)
     }
-   func log(message: String) {
+
+    func log(message: String) {
         os_log("%@", log: log, type: .info, message)
     }
 }
+

--- a/Survey/Survey/Logger.swift
+++ b/Survey/Survey/Logger.swift
@@ -1,9 +1,17 @@
 import Foundation
+import os
 
 class Logger {
     static let shared = Logger()
-    private init() {}
+    private let log: OSLog
+
+    private init() {
+        self.log = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.yourapp.default", category: "General")
+    }
     func log(error: Error) {
-        print("Error logged: \(error.localizedDescription)")
+        os_log("Error logged: %@", log: log, type: .error, error.localizedDescription)
+    }
+   func log(message: String) {
+        os_log("%@", log: log, type: .info, message)
     }
 }

--- a/Survey/Survey/Models/InquiryModel.swift
+++ b/Survey/Survey/Models/InquiryModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Inquiry: Codable, Identifiable {
+    let id: Int
+    let question: String
+}

--- a/Survey/Survey/Models/SurveyModel.swift
+++ b/Survey/Survey/Models/SurveyModel.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Combine
+
+class SurveyViewModel: ObservableObject {
+    @Published var inquiries: [Inquiry] = []
+    private var cancellables = Set<AnyCancellable>()
+    private let mockServer = MockServer()
+
+    init() {
+        loadInquiries()
+    }
+
+    func loadInquiries() {
+        attemptLoadInquiries()
+    }
+
+    private func attemptLoadInquiries() {
+        mockServer.loadInquiries()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.shared.log(error: error)
+                    self?.retryLoadInquiries()
+                }
+            }, receiveValue: { [weak self] inquiries in
+                self?.inquiries = inquiries
+            })
+            .store(in: &cancellables)
+    }
+
+    private func retryLoadInquiries() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            self.attemptLoadInquiries()
+        }
+    }
+}

--- a/Survey/Survey/Network/InquiryService.swift
+++ b/Survey/Survey/Network/InquiryService.swift
@@ -1,0 +1,4 @@
+import Combine
+protocol InquiryService {
+    func loadInquiries() -> AnyPublisher<[Inquiry], Error>
+}

--- a/Survey/Survey/Network/MockServer.swift
+++ b/Survey/Survey/Network/MockServer.swift
@@ -1,11 +1,12 @@
 import Foundation
 import Combine
-class MockServer {
+class MockServer: InquiryService {
     func loadInquiries() -> AnyPublisher<[Inquiry], Error> {
         guard let url = Bundle.main.url(forResource: "db", withExtension: "json") else {
             let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "File not found"])
             return Fail(error: error).eraseToAnyPublisher()
         }
+        
         return URLSession.shared.dataTaskPublisher(for: url)
             .map { $0.data }
             .decode(type: [Inquiry].self, decoder: JSONDecoder())

--- a/Survey/Survey/Network/MockServer.swift
+++ b/Survey/Survey/Network/MockServer.swift
@@ -4,6 +4,7 @@ class MockServer: InquiryService {
     func loadInquiries() -> AnyPublisher<[Inquiry], Error> {
         guard let url = Bundle.main.url(forResource: "db", withExtension: "json") else {
             let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "File not found"])
+            Logger.shared.log(error: error, customMessage: "Failed to load inquiries")
             return Fail(error: error).eraseToAnyPublisher()
         }
         return URLSession.shared.dataTaskPublisher(for: url)
@@ -11,7 +12,7 @@ class MockServer: InquiryService {
             .decode(type: [Inquiry].self, decoder: JSONDecoder())
             .handleEvents(receiveCompletion: { completion in
                 if case .failure(let error) = completion {
-                    Logger.shared.log(error: error)
+                    Logger.shared.log(error: error, customMessage: "Network request failed")
                 }
             })
             .eraseToAnyPublisher()

--- a/Survey/Survey/Network/MockServer.swift
+++ b/Survey/Survey/Network/MockServer.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Combine
+class MockServer {
+    func loadInquiries() -> AnyPublisher<[Inquiry], Error> {
+        guard let url = Bundle.main.url(forResource: "db", withExtension: "json") else {
+            let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "File not found"])
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+        return URLSession.shared.dataTaskPublisher(for: url)
+            .map { $0.data }
+            .decode(type: [Inquiry].self, decoder: JSONDecoder())
+            .handleEvents(receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    Logger.shared.log(error: error)
+                }
+            })
+            .eraseToAnyPublisher()
+    }
+}

--- a/Survey/Survey/Network/MockServer.swift
+++ b/Survey/Survey/Network/MockServer.swift
@@ -6,7 +6,6 @@ class MockServer: InquiryService {
             let error = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "File not found"])
             return Fail(error: error).eraseToAnyPublisher()
         }
-        
         return URLSession.shared.dataTaskPublisher(for: url)
             .map { $0.data }
             .decode(type: [Inquiry].self, decoder: JSONDecoder())

--- a/Survey/Survey/Network/db.json
+++ b/Survey/Survey/Network/db.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": 1,
+    "question": "How was your meeting?"
+  }
+]

--- a/Survey/Survey/Survey.entitlements
+++ b/Survey/Survey/Survey.entitlements
@@ -4,7 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>

--- a/Survey/Survey/SurveyApp.swift
+++ b/Survey/Survey/SurveyApp.swift
@@ -21,6 +21,5 @@ struct SurveyApp: App {
             ContentView()
         }
         .modelContainer(sharedModelContainer)
-    
     }
 }

--- a/Survey/Survey/SurveyApp.swift
+++ b/Survey/Survey/SurveyApp.swift
@@ -21,5 +21,6 @@ struct SurveyApp: App {
             ContentView()
         }
         .modelContainer(sharedModelContainer)
+    
     }
 }

--- a/Survey/Survey/SurveyView.swift
+++ b/Survey/Survey/SurveyView.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
 struct SurveyView: View {
+    var question: String
     @State private var selectedOption: String?
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("How was your day?")
+            Text(question)
                 .font(.title)
                 .padding()
 
@@ -41,7 +42,6 @@ struct SurveyView: View {
             }
             .padding(.horizontal)
 
-            // Display the selected option
             if let selectedOption = selectedOption {
                 Text("You selected: \(selectedOption)")
                     .padding()
@@ -52,7 +52,6 @@ struct SurveyView: View {
     }
 }
 
-// Custom button style for colored buttons
 struct CustomButtonStyle: ButtonStyle {
     var color: Color
 
@@ -68,6 +67,6 @@ struct CustomButtonStyle: ButtonStyle {
 
 struct SurveyView_Previews: PreviewProvider {
     static var previews: some View {
-        SurveyView()
+        SurveyView(question: "How was your day?")
     }
 }

--- a/Survey/Survey/SurveyView.swift
+++ b/Survey/Survey/SurveyView.swift
@@ -11,35 +11,31 @@ struct SurveyView: View {
                 .foregroundColor(.black)
                 .padding()
 
-            // Buttons arranged in two rows
-            VStack(spacing: 10) {
-                HStack {
-                    Button("Awful") {
-                        self.selectedOption = "Awful"
-                    }
-                    .buttonStyle(CustomButtonStyle(color: .red))
-
-                    Button("Bad") {
-                        self.selectedOption = "Bad"
-                    }
-                    .buttonStyle(CustomButtonStyle(color: .orange))
-
-                    Button("Decent") {
-                        self.selectedOption = "Decent"
-                    }
-                    .buttonStyle(CustomButtonStyle(color: .blue))
+            HStack {
+                Button("Awful") {
+                    self.selectedOption = "Awful"
                 }
-                HStack {
-                    Button("Good") {
-                        self.selectedOption = "Good"
-                    }
-                    .buttonStyle(CustomButtonStyle(color: .green))
+                .buttonStyle(CustomButtonStyle(color: .red))
 
-                    Button("Great") {
-                        self.selectedOption = "Great"
-                    }
-                    .buttonStyle(CustomButtonStyle(color: .green))
+                Button("Bad") {
+                    self.selectedOption = "Bad"
                 }
+                .buttonStyle(CustomButtonStyle(color: .orange))
+
+                Button("Decent") {
+                    self.selectedOption = "Decent"
+                }
+                .buttonStyle(CustomButtonStyle(color: .blue))
+
+                Button("Good") {
+                    self.selectedOption = "Good"
+                }
+                .buttonStyle(CustomButtonStyle(color: .green))
+
+                Button("Great") {
+                    self.selectedOption = "Great"
+                }
+                .buttonStyle(CustomButtonStyle(color: .green))
             }
             .padding(.horizontal)
 

--- a/Survey/Survey/SurveyView.swift
+++ b/Survey/Survey/SurveyView.swift
@@ -8,6 +8,7 @@ struct SurveyView: View {
         VStack(spacing: 20) {
             Text(question)
                 .font(.title)
+                .foregroundColor(.black)
                 .padding()
 
             // Buttons arranged in two rows


### PR DESCRIPTION
Ticket SR-85 https://incredihire-academy.atlassian.net/browse/SR-85

ACCEPTANCE CRITERIA

When app starts up, it should query the server for the Inquiry it should display

(Note: can use mock server until the real API is available)

If the app gets back the Inquiry, it should show this Inquiry on the main screen

If the app gets back an error, it should retry at 10 minute intervals. 

This can be done by app scheduling itself to run again in 10 mins and quitting

Or the app can simply not show the main window and silently retry until it succeeds. Either way.

 

Notes:

Can use [JSONPlaceholder - Free Fake REST API](https://jsonplaceholder.typicode.com/)  as placeholder for now, but make sure API path/response format matches design doc.